### PR TITLE
Use custom fonts across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
   <title>ryduzz</title>
   <meta name="description" content="ryduzz — Professional video editor (AE, PR, DaVinci, CapCut). 100M+ views. Shorts & long-form." />
 
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=DM+Serif+Display&display=swap" rel="stylesheet">
+  <link href="https://fonts.cdnfonts.com/css/coolvetica" rel="stylesheet">
+
   <style>
     :root{
       --bg:#0b0b0f;
@@ -44,7 +47,7 @@
     }
 
     *{box-sizing:border-box}
-    html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:"Georgia","Garamond","Times New Roman",serif;position:relative}
+    html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:"Inter",sans-serif;position:relative}
     body::before{
       content:"";
       position:fixed; inset:0;
@@ -62,6 +65,9 @@
     a{color:inherit;text-decoration:none}
     img{max-width:100%;height:auto;display:block}
     .container{width:min(100%, var(--maxw));margin-inline:auto;padding:0 20px}
+
+    strong{font-family:"DM Serif Display",serif;font-weight:400}
+    h1, h2, .title, .brand{font-family:"Coolvetica",sans-serif}
 
     /* Soft animated background */
     .bg-orb{


### PR DESCRIPTION
## Summary
- Add Google and CDN font imports for Inter, DM Serif Display, and Coolvetica
- Set Inter as default font, Coolvetica for titles, and DM Serif Display for highlighted text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b89d733f6c832981412a3e4a4c5d65