### PR TITLE
docs: add project README with badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# ryduzz
+
+[![GitHub Pages](https://img.shields.io/badge/hosted%20on-GitHub%20Pages-blue?logo=github)](https://ryderjt.github.io/ryduzz/)
+[![Last Commit](https://img.shields.io/github/last-commit/ryderjt/ryduzz?logo=github)](https://github.com/ryderjt/ryduzz/commits)
+[![Repo Size](https://img.shields.io/github/repo-size/ryderjt/ryduzz)](https://github.com/ryderjt/ryduzz)
+
+A minimalist portfolio website for the video editor known as **ryduzz**, showcasing past work and contact information.
+
+## Development
+
+This repository hosts a static site served through GitHub Pages. Edit `index.html` and open it in your browser to preview changes.
+
+## Deployment
+
+Push to the `main` branch and GitHub Pages will rebuild the site automatically.
+


### PR DESCRIPTION
## Summary
- document project purpose and hosting
- add Shields.io badges for GitHub Pages, last commit, and repository size

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8a62dd2948329b26334e7b114806e