### PR TITLE
Rename Past Work section and update button link

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,10 +556,10 @@
           >
           <a
             class="btn"
-            href="https://www.youtube.com/@ryduzzz"
+            href="https://drive.google.com/drive/folders/1yhpCQUQz16OSSIvKOt3jNoGMWS0DmQCS"
             target="_blank"
             rel="noopener"
-            title="Past work on YouTube"
+            title="Portfolio on Google Drive"
             >Past Work</a
           >
           <a class="btn" href="#contact">Hire Me</a>
@@ -639,9 +639,9 @@
       <!-- WORK (CAROUSEL) -->
       <section id="work">
         <div class="container">
-          <h2 class="reveal">Past Work</h2>
+          <h2 class="reveal">Portfolio</h2>
 
-          <div class="card reveal carousel" aria-label="Past Work Carousel">
+          <div class="card reveal carousel" aria-label="Portfolio Carousel">
             <div class="stage" id="stage">
               <div
                 class="card-vid center"
@@ -917,7 +917,7 @@
       function setIframe(target, id) {
         target.innerHTML = "";
         const iframe = document.createElement("iframe");
-        iframe.title = "Past Work";
+        iframe.title = "Portfolio";
         iframe.allow =
           "accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share";
         iframe.allowFullscreen = true;


### PR DESCRIPTION
## Summary
- Rename Past Work section heading and carousel label to Portfolio for consistent branding.
- Point top "Past Work" button to Google Drive portfolio in a new tab and update iframe titles accordingly.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ec68f99883299d0896592377dc77