### PR TITLE
Fix hero section spacing on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,8 @@
       }
 
       .hero {
-        padding: 72px 0 36px;
+        padding-top: 72px;
+        padding-bottom: 36px;
       }
       .title {
         font-size: clamp(36px, 6vw, 64px);


### PR DESCRIPTION
## Summary
- ensure hero's top/bottom padding doesn't override container's horizontal spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb77fe448329afa37d779f3d8851