### PR TITLE
feat: refresh site styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,12 @@
       name="description"
       content="ryduzz — Professional video editor (AE, PR, DaVinci). 100M+ views. Shorts & long-form."
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
 
     <style>
       :root {
@@ -53,8 +59,8 @@
         --text: #1d1d1f;
         --muted: #6e6e73;
         --line: #d2d2d7;
-        --accent-1: #0071e3;
-        --accent-2: #2997ff;
+        --accent-1: #ff6ec4;
+        --accent-2: #7873f5;
         --accent-3: #1d1d1f;
         --radius: 14px;
         --maxw: 1100px;
@@ -69,8 +75,8 @@
         --text: #f5f5f7;
         --muted: #a1a1a6;
         --line: #3a3a3c;
-        --accent-1: #0a84ff;
-        --accent-2: #409cff;
+        --accent-1: #ff6ec4;
+        --accent-2: #7873f5;
         --accent-3: #ffffff;
       }
 
@@ -84,7 +90,7 @@
         background: var(--bg);
         color: var(--text);
         font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           "Helvetica Neue", Arial, sans-serif;
         position: relative;
       }
@@ -105,7 +111,7 @@
         background: linear-gradient(-45deg, var(--accent-1), var(--accent-2));
         background-size: 400% 400%;
         animation: gradient 20s ease infinite;
-        opacity: 0.15;
+        opacity: 0.25;
       }
       @keyframes gradient {
         0% {
@@ -328,18 +334,23 @@
         grid-template-columns: repeat(12, 1fr);
       }
       .card {
-        background: linear-gradient(180deg, var(--card), var(--card-2));
-        border: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.25);
+        border: 1px solid rgba(255, 255, 255, 0.18);
         border-radius: var(--radius);
         padding: 18px;
+        backdrop-filter: blur(10px);
         box-shadow: var(--shadow);
         transition:
           transform 0.3s var(--ease),
           box-shadow 0.3s var(--ease);
       }
+      html.dark .card {
+        background: rgba(28, 28, 30, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
       .card:hover {
         transform: translateY(-4px);
-        box-shadow: 0 15px 30px rgba(0, 0, 0, 0.2);
+        box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
       }
       .span-4 {
         grid-column: span 4;


### PR DESCRIPTION
## Summary
- add Poppins font and neon accent palette
- enhance background gradient and enable glassmorphic cards

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx prettier --check index.html` *(warn: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c492d1748329aa4ba22b6a9dcd37