### PR TITLE
Update site view count to 25 million

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta property="og:title" content="ryduzz • Video Editor" />
     <meta
       property="og:description"
-      content="Professional video editor (AE, PR, DaVinci). 100M+ views. Shorts & long-form."
+      content="Professional video editor (AE, PR, DaVinci). 25 million+ views. Shorts & long-form."
     />
     <meta
       property="og:image"
@@ -27,7 +27,7 @@
     <meta name="twitter:title" content="ryduzz — Video Editor" />
     <meta
       name="twitter:description"
-      content="Professional video editor (AE, PR, DaVinci). 100M+ views. Shorts & long-form."
+      content="Professional video editor (AE, PR, DaVinci). 25 million+ views. Shorts & long-form."
     />
     <meta
       name="twitter:image"
@@ -42,7 +42,7 @@
     <title>ryduzz</title>
     <meta
       name="description"
-      content="ryduzz — Professional video editor (AE, PR, DaVinci). 100M+ views. Shorts & long-form."
+      content="ryduzz — Professional video editor (AE, PR, DaVinci). 25 million+ views. Shorts & long-form."
     />
 
     <style>
@@ -609,7 +609,7 @@
       <!-- HERO -->
       <section class="hero container">
         <span class="badge reveal" aria-label="Stats"
-          >100M+ views • 5+ years editing • AE · PR · DaVinci</span
+          >25 million+ views • 5+ years editing • AE · PR · DaVinci</span
         >
         <h1 class="title reveal" style="margin-top: 14px">
           Editor for Shorts & Long-Form Content
@@ -683,7 +683,7 @@
               work in <em>After Effects</em>, <em>Premiere Pro</em>, and
               <em>DaVinci Resolve</em> to create engaging content that maximizes
               retention. Across my edits I’ve pulled in over
-              <strong>100 million views</strong>, and I specialize in turning
+              <strong>25 million views</strong>, and I specialize in turning
               raw clips into content that pops on Shorts, Reels, and YouTube.
             </p>
             <p>
@@ -698,7 +698,7 @@
             <ul class="list">
               <li>5+ years editing experience</li>
               <li>CapCut Affiliate Creator</li>
-              <li>100M+ views across edits</li>
+              <li>25 million+ views across edits</li>
               <li>Fast, reliable turnaround</li>
               <li>Clear communication & revisions</li>
             </ul>


### PR DESCRIPTION
## Summary
- update marketing copy to reflect 25 million+ views across meta tags, hero badge, and quick facts
- align the about section copy with the new 25 million view milestone

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d368896d608329807e566b86976c7a