### PR TITLE
Add featured video embed below portfolio carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -755,6 +755,19 @@
               >Full Portfolio</a
             >
           </div>
+
+          <div class="card reveal" style="margin-top: 18px" aria-label="Featured video">
+            <h3 style="margin-top: 0">Featured Video</h3>
+            <div class="embed">
+              <iframe
+                src="https://www.youtube.com/embed/hz4sMfnhx5g?rel=0&modestbranding=1&playsinline=1"
+                title="Featured portfolio video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowfullscreen
+                loading="lazy"
+              ></iframe>
+            </div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a new card beneath the portfolio carousel to highlight a featured video
- embed the provided YouTube clip inside the existing rounded card styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2bf8a75fc8329af5c7a0924884a90