### PR TITLE
Adjust portfolio link placement under video

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,15 +745,25 @@
             </div>
           </div>
 
-          <!-- Text link under carousel -->
-          <div class="reveal" style="text-align: center; margin-top: 6px">
-            <a
-              class="textlink"
-              href="https://drive.google.com/drive/folders/1yhpCQUQz16OSSIvKOt3jNoGMWS0DmQCS?usp=drive_link"
-              target="_blank"
-              rel="noopener"
-              >Full Portfolio</a
-            >
+          <div class="card reveal" style="margin-top: 18px" aria-label="Featured video">
+            <div class="embed">
+              <iframe
+                src="https://www.youtube.com/embed/hz4sMfnhx5g?rel=0&modestbranding=1&playsinline=1"
+                title="Featured portfolio video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowfullscreen
+                loading="lazy"
+              ></iframe>
+            </div>
+            <div style="text-align: center; margin-top: 12px">
+              <a
+                class="textlink"
+                href="https://drive.google.com/drive/folders/1yhpCQUQz16OSSIvKOt3jNoGMWS0DmQCS?usp=drive_link"
+                target="_blank"
+                rel="noopener"
+                >Full Portfolio</a
+              >
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add a new card beneath the portfolio carousel to highlight a featured video
- embed the provided YouTube clip inside the existing rounded card styling and move the full portfolio link beneath the video while removing the redundant heading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bf8a75fc8329af5c7a0924884a90