### PR TITLE
Adjust portfolio layout and hide scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,12 @@
           "Helvetica Neue", Arial, sans-serif;
         position: relative;
       }
+      body {
+        scrollbar-width: none;
+      }
+      body::-webkit-scrollbar {
+        display: none;
+      }
       a {
         color: inherit;
         text-decoration: none;
@@ -755,28 +761,15 @@
                 loading="lazy"
               ></iframe>
             </div>
-            <div style="text-align: center; margin-top: 12px">
-              <a
-                class="textlink"
-                href="https://drive.google.com/drive/folders/1yhpCQUQz16OSSIvKOt3jNoGMWS0DmQCS?usp=drive_link"
-                target="_blank"
-                rel="noopener"
-                >Full Portfolio</a
-              >
-            </div>
           </div>
-
-          <div class="card reveal" style="margin-top: 18px" aria-label="Featured video">
-            <h3 style="margin-top: 0">Featured Video</h3>
-            <div class="embed">
-              <iframe
-                src="https://www.youtube.com/embed/hz4sMfnhx5g?rel=0&modestbranding=1&playsinline=1"
-                title="Featured portfolio video"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                allowfullscreen
-                loading="lazy"
-              ></iframe>
-            </div>
+          <div class="reveal" style="margin-top: 18px; text-align: center">
+            <a
+              class="textlink"
+              href="https://drive.google.com/drive/folders/1yhpCQUQz16OSSIvKOt3jNoGMWS0DmQCS?usp=drive_link"
+              target="_blank"
+              rel="noopener"
+              >Full Portfolio</a
+            >
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- remove the duplicate featured video block
- move the full portfolio link to the bottom of the portfolio section
- hide the page scrollbar for a cleaner presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2cfea15808329bafcf7ea902b212f